### PR TITLE
 Add support for machine-only mode to skip VultrCluster dependency

### DIFF
--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -22,3 +22,7 @@ func CreateVultrClient() (*govultr.Client, error) {
 
 	return vultrClient, nil
 }
+
+func MachineOnly() bool {
+	return os.Getenv("VULTR_MACHINE_ONLY") == "true"
+}

--- a/cloud/services/instance.go
+++ b/cloud/services/instance.go
@@ -89,7 +89,7 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*govultr.Instance, 
 	instanceReq := &govultr.InstanceCreateReq{
 		Label:      instanceName,
 		Hostname:   instanceName,
-		Region:     s.scope.Region(),
+		Region:     scope.VultrMachine.Spec.Region,
 		Plan:       scope.VultrMachine.Spec.PlanID,
 		SSHKeys:    sshKeyIDs,
 		SnapshotID: scope.VultrMachine.Spec.Snapshot,

--- a/internal/controller/vultrmachine_controller.go
+++ b/internal/controller/vultrmachine_controller.go
@@ -99,13 +99,13 @@ func (r *VultrMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		Namespace: vultrMachine.Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
-	if err := r.Client.Get(ctx, vultrClusterName, vultrCluster); err != nil {
+	if err := r.Client.Get(ctx, vultrClusterName, vultrCluster); err != nil && !scope.MachineOnly() {
 		log.Info("VultrCluster is not available yet.")
 		return ctrl.Result{}, nil
 	}
 
 	// Return early if the object or Cluster is paused.
-	if annotations.IsPaused(cluster, vultrCluster) {
+	if annotations.IsPaused(cluster, vultrCluster) && !scope.MachineOnly() {
 		log.Info("VultrMachine or linked Cluster is marked as paused. Won't reconcile")
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
### Description

  This PR introduces a "machine-only" mode that allows `VultrMachine` resources to be reconciled independently without requiring a `VultrCluster` to be present. The feature is controlled by the `VULTR_MACHINE_ONLY` environment variable.

### Key Changes:
  - Added `MachineOnly()` helper function in cloud/scope/common.go that checks the `VULTR_MACHINE_ONLY` environment variable
  - Modified `VultrMachine` controller reconciliation logic to conditionally skip `VultrCluster` dependency checks when in machine-only mode
  - Updated instance creation to use the machine's region specification directly instead of cluster scope
  - Maintains full backwards compatibility - existing deployments continue to work unchanged

### Use Cases:
  - Standalone `VultrMachine` management without cluster-level infrastructure
  - Testing and development scenarios where cluster dependency is not needed
  - Simplified deployment workflows for single-machine setups

### Related Issues

  Related to #69 - Add support for machine-only mode to skip VultrCluster dependency

### Checklist:

  - [x] Have you checked to ensure there aren't other open ../../../pulls for the same update/change?
  - [x] Have you linted your code locally prior to submission?
  - [x] Have you successfully ran tests with your changes locally?

