### PR TITLE
Add VPC ID to VultrCluster CRDs

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -111,7 +111,6 @@ type GenericInfo struct {
 	SSLRedirect        *bool           `json:"ssl_redirect,omitempty"`
 	StickySessions     *StickySessions `json:"sticky_sessions,omitempty"`
 	ProxyProtocol      *bool           `json:"proxy_protocol,omitempty"`
-	PrivateNetwork     string          `json:"private_network,omitempty"`
 	VPC                string          `json:"vpc,omitempty"`
 }
 

--- a/api/v1beta1/vultrcluster_types.go
+++ b/api/v1beta1/vultrcluster_types.go
@@ -43,6 +43,10 @@ type VultrClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// VPCID is the Vultr VPC ID used for the cluster's load balancer.
+	// +optional
+	VPCID string `json:"vpc_id,omitempty"`
 }
 
 // VultrClusterStatus defines the observed state of VultrCluster

--- a/api/v1beta1/vultrmachine_types.go
+++ b/api/v1beta1/vultrmachine_types.go
@@ -53,7 +53,7 @@ type VultrMachineSpec struct {
 	// +optional
 	SSHKey []string `json:"sshKey,omitempty"`
 
-	// VPCID is the id of the VPC to be attched.
+	// VPCID is the id of the VPC to be attached.
 	// +optional
 	VPCID string `json:"vpc_id,omitempty"`
 
@@ -61,7 +61,7 @@ type VultrMachineSpec struct {
 	// +optional
 	FirewallGroupID string `json:"firewall_group_id,omitempty"`
 
-	// VPC2ID is the id of the VPC2.0 to be attched .
+	// VPC2ID is the id of the VPC2.0 to be attached.
 	// Deprecated: VPC2 is no longer supported and functionality will cease in a
 	// future release
 	// +optional

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -135,7 +135,10 @@ func (s *ClusterScope) SetControlPlaneEndpoint(apiEndpoint clusterv1.APIEndpoint
 	s.VultrCluster.Spec.ControlPlaneEndpoint = apiEndpoint
 }
 
-// // VPC gets the VultrCluster Spec Network VPC.
-// func (s *ClusterScope) VPC() *infrav1.VultrVPC {
-// 	return &s.VultrCluster.Spec.Network.VPCID
-// }
+// VPC returns the cluster VPCID if set
+func (s *ClusterScope) VPC() *string {
+	if s.VultrCluster.Spec.VPCID != "" {
+		return &s.VultrCluster.Spec.VPCID
+	}
+	return nil
+}

--- a/cloud/services/loadbalancer.go
+++ b/cloud/services/loadbalancer.go
@@ -40,6 +40,7 @@ func (s *Service) CreateLoadBalancer(spec *infrav1.VultrLoadBalancer) (*govultr.
 	createReq := &govultr.LoadBalancerReq{
 		Label:  name,
 		Region: s.scope.Region(),
+		VPC:    s.scope.VPC(),
 		ForwardingRules: []govultr.ForwardingRule{
 			{
 				FrontendProtocol: "tcp",

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrclusters.yaml
@@ -118,8 +118,6 @@ spec:
                         properties:
                           balancing_algorithm:
                             type: string
-                          private_network:
-                            type: string
                           proxy_protocol:
                             type: boolean
                           ssl_redirect:
@@ -177,6 +175,10 @@ spec:
                 type: object
               region:
                 description: The Vultr Region (DCID) the cluster lives on
+                type: string
+              vpc_id:
+                description: VPCID is the Vultr VPC ID used for the cluster's load
+                  balancer.
                 type: string
             required:
             - region

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrclustertemplates.yaml
@@ -115,8 +115,6 @@ spec:
                                 properties:
                                   balancing_algorithm:
                                     type: string
-                                  private_network:
-                                    type: string
                                   proxy_protocol:
                                     type: boolean
                                   ssl_redirect:
@@ -174,6 +172,10 @@ spec:
                         type: object
                       region:
                         description: The Vultr Region (DCID) the cluster lives on
+                        type: string
+                      vpc_id:
+                        description: VPCID is the Vultr VPC ID used for the cluster's
+                          load balancer.
                         type: string
                     required:
                     - region

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrmachines.yaml
@@ -85,11 +85,11 @@ spec:
                   type: string
                 type: array
               vpc_id:
-                description: VPCID is the id of the VPC to be attched.
+                description: VPCID is the id of the VPC to be attached.
                 type: string
               vpc2_id:
                 description: |-
-                  VPC2ID is the id of the VPC2.0 to be attched .
+                  VPC2ID is the id of the VPC2.0 to be attached.
                   Deprecated: VPC2 is no longer supported and functionality will cease in a
                   future release
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vultrmachinetemplates.yaml
@@ -76,11 +76,11 @@ spec:
                           type: string
                         type: array
                       vpc_id:
-                        description: VPCID is the id of the VPC to be attched.
+                        description: VPCID is the id of the VPC to be attached.
                         type: string
                       vpc2_id:
                         description: |-
-                          VPC2ID is the id of the VPC2.0 to be attched .
+                          VPC2ID is the id of the VPC2.0 to be attached.
                           Deprecated: VPC2 is no longer supported and functionality will cease in a
                           future release
                         type: string


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

* Allow users to attach a VPC to the cluster load balancer on creation.

```
---
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: VultrCluster
metadata:
  name: "${CLUSTER_NAME}"
spec:
  region: "${REGION}"
  vpc_id: "${VPCID}" 
  ```
  * Remove deprecated PrivateNetwork fields
  * Fix Typos

## Related Issues

### Checklist:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
