### PR TITLE
Replace deprecated kubebuilder kube-rbac-proxy image

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->

`kube-rbac-proxy` usage has been discontinued in [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder). In the meantime, we will replace the current gcr image to prevent the project from failing when trying to pull from that registry.  This is a temporary fix while we work on regenerating the kubebuilder scaffolding which would allow us to take advantage of other improvements, bug fixes, and the latest updates.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
