### PR TITLE
feature: VPC only/private instances as Kubernetes nodes

### DIFF
--- a/api/v1beta2/vultrmachine_types.go
+++ b/api/v1beta2/vultrmachine_types.go
@@ -52,6 +52,7 @@ type VultrMachineSpec struct {
 	VPCID string `json:"vpc_id,omitempty"`
 
 	//VPCOnly indicates that the VPS will not receive a public IP or public NIC when true.
+	// +optional
 	VPCOnly bool `json:"vpc_only,omitempty"`
 
 	//The Vultr firewall group ID to attach to the instance

--- a/cloud/services/instance.go
+++ b/cloud/services/instance.go
@@ -97,6 +97,11 @@ func (s *Service) CreateInstance(scope *scope.MachineScope) (*govultr.Instance, 
 		EnableIPv6: util.Pointer(true),
 	}
 
+	if scope.VultrMachine.Spec.VPCOnly {
+		instanceReq.VPCOnly = util.Pointer(true)
+		instanceReq.DisablePublicIPv4 = util.Pointer(true)
+	}
+
 	if scope.VultrMachine.Spec.VPCID != "" {
 		instanceReq.AttachVPC = append(instanceReq.AttachVPC, scope.VultrMachine.Spec.VPCID)
 	}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -169,6 +169,12 @@ capvultr-quickstart-md-0-b54j9-2szdn      NotReady   <none>          14m   v1.28
 capvultr-quickstart-md-0-b54j9-vb5tz      NotReady   <none>          14m   v1.28.9
 ```
 
+### Private/VPC Only Nodes/Instances
+
+To create private instances/k8s nodes without a public IPv4 address, set `vpc_only: true` on the `VultrMachineTemplate.spec.template.spec` entries in the rendered cluster manifest.
+
+When using private instances, also populate `spec.vpc_id` on the `VultrCluster`. This ensures the control plane load balancer is created in the same VPC and can reach the control plane nodes.
+
 ### Deploy CNI
 
 Cilium is used here as an example but you can bring your own CNI.


### PR DESCRIPTION
Kubernetes nodes should be private for security reasons. 
Current CAPVultr has hardcoded behaviour to create Vultr instances with public IP.

## Summary

- Reuse `VultrMachine.spec.vpc_only` to create private instances without a public IPv4 address.
- Keep the change narrowly scoped to instance creation behavior.
- Preserve existing default behavior when `vpc_only` is not set.

## Base Branch Note

This PR is deliberately built on top of the branch from https://github.com/vultr/cluster-api-provider-vultr/pull/143.
to make it easy to merge this PR after PR #143 

## Changes

- `cloud/services/instance.go`
  - when `spec.vpc_only=true`, set `VPCOnly=true`
  - when `spec.vpc_only=true`, set `DisablePublicIPv4=true`
- `api/v1beta2/vultrmachine_types.go`
  - keep the existing `VPCOnly` field comment
  - add the missing `+optional` marker
- `docs/getting-started.md`
  - document `vpc_only=true` for private-instance creation

## Tests
- successfully created kubernetes cluster on Vultr private instances using CAPI 1.13.2
